### PR TITLE
Solução bug de novos clones do repo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   jekyll-serve:
-    image: jekyll/jekyll
+    image: jekyll/jekyll:4.2.0
     volumes:
       - .:/srv/jekyll
     ports:


### PR DESCRIPTION
#### Problema:
A imagem docker do jekyll atualizou para a versão 3.1 do Ruby, isso ocasiona um erro para novos clones do repo.

#### Solução
Travei a versão do Jekyll na 4.2.0 com o Ruby 2.7