### PR TITLE
add highlightjs

### DIFF
--- a/_layouts/template.html
+++ b/_layouts/template.html
@@ -8,13 +8,16 @@
 	<meta property="og:title" content= "{{ page.title }}">
 	<!-- css & js-->
 	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-	<link href="/assets/css/styles.css" rel="stylesheet">
-	<link href="/assets/css/offcanvas.css" rel="stylesheet">
-	<link href="/assets/images/favicon.ico" rel="icon" type="image/x-icon" >
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css" rel="stylesheet" >
 	<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js" integrity="sha384-7+zCNj/IqJ95wo16oMtfsKbZ9ccEh31eOz1HGyDuCQ6wgnyJNSYdrPa03rtR1zdB" crossorigin="anonymous"></script>
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js" integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-	<script src="../assets/js/offcanvas.js"></script>
+	<link href="/assets/css/styles.css" rel="stylesheet">
+	<link href="/assets/images/favicon.ico" rel="icon" type="image/x-icon" >
+	<link href="/assets/css/offcanvas.css" rel="stylesheet">
+	<script src="/assets/js/offcanvas.js"></script>
+	<script>hljs.highlightAll();</script>
 </head>
 {%- assign filtered_pages = site.pages | where: 'type', 'post' -%}
 {%- assign filtered_pages_wiki = site.pages | where: 'type', 'wiki' -%}

--- a/programacao_competitiva/erros_comuns.md
+++ b/programacao_competitiva/erros_comuns.md
@@ -19,7 +19,8 @@ Dentre os erros mais comuns, baseado nos problemas “Iniciante” estão:
 
 ### Wrong Answer (Resposta errada)
 - Impressão de mensagens fora da especificação (pedir entrada, sem o formato do exemplo)
-```
+
+```c++
 cout << “Digite a distância: ”;
 ```
 
@@ -27,14 +28,14 @@ cout << “Digite a distância: ”;
 - Sinal de igualdade para atribuição (expressão lógica com sintaxe incorreta)
 
 **Código errado:**
-```
+```c++
 if(i = 0){
       //trecho de código
    }
 ```
 
 **Código certo:**
-```
+```c++
 if(i == 0){
       //trecho de código
    }


### PR DESCRIPTION
Adicionei o [highlightjs](https://highlightjs.org/) ao projeto. (Fiquem a vontade para ler a documentação)
- Fix #52 

#### Utilização
1. Para usar é simples, use a tag de código do markdown ` ``` code here! ``` ` 
2. Bem... É isso.

Obs: Você pode especificar a linguagem em que está escrita o código, assim o [highlightjs](https://highlightjs.org/) selecionará o css especifico para ela. Dessa forma:  ` ``` code here! ```c++ ` ou ` ``` code here! ```Python `

<details><summary>As linguagens disponíveis são</summary>

- Bash
- C 
- C# 
- C++ 
- CSS 
- Diff 
- Go
- HTML, XML 
- JSON 
- Java
- JavaScript 
- Kotlin 
- Less 
- Lua
- Makefile 
- Markdown 
- Objective-C 
- PHP 
- PHP Template 
- Perl 
- Plain text 
- Python 
- Python REPL 
- R 
- Ruby 
- Rust 
- SCSS 
- SQL 
- Shell 
- Session 
- Swift 
- TOML, also INI 
- TypeScript 
- Visual Basic 
- .NET 
- YAML
</details>

@JoaoVitorPSilva nessa mesma branch, faça um push aplicando o estilo a todos os _code blocks_ do site, por favor. 