### PR TITLE
Organizar tópicos de Programação Competitiva

### DIFF
--- a/posts/programacao_competitiva.md
+++ b/posts/programacao_competitiva.md
@@ -5,7 +5,8 @@ button: Programação competitiva
 filename: programacao_competitiva
 type: post
 ---
-{%- assign programacao_competitiva_pages = site.pages | where: 'type', 'programacao_competitiva' -%}
+{%- assign programacao_competitiva_pages = site.pages | where: 'type', 'programacao_competitiva'
+		| sort: 'order' -%}
 
 # Programação competitiva
 

--- a/programacao_competitiva/classe_problemas.md
+++ b/programacao_competitiva/classe_problemas.md
@@ -4,6 +4,7 @@ layout: template
 filename: classe_problema
 button: Classe dos problemas
 type: programacao_competitiva
+order: 1
 ---
 # Classe dos problemas
 

--- a/programacao_competitiva/comparar_arquivos.md
+++ b/programacao_competitiva/comparar_arquivos.md
@@ -3,8 +3,9 @@ title: Comparar arquivos
 layout: template
 button: Comparar arquivos
 filename: comparar_arquivos
-type: treinamento
---- 
+type: programacao_competitiva
+order: 5
+---
 
 Como comparar arquivos de texto usando diff
 -------------------------------------------

--- a/programacao_competitiva/erros_comuns.md
+++ b/programacao_competitiva/erros_comuns.md
@@ -4,6 +4,7 @@ layout: template
 filename: erros_comuns
 button: Erros comuns
 type: programacao_competitiva
+order: 4
 ---
 # Erros Comuns
 

--- a/programacao_competitiva/formato_problemas.md
+++ b/programacao_competitiva/formato_problemas.md
@@ -4,6 +4,7 @@ layout: template
 filename: formato_problemas
 button: Formato dos problemas
 type: programacao_competitiva
+order: 2
 ---
 # Formato dos problemas
 Os enunciados dos problemas de programação competitiva seguem um padrão próprio das competições. O problema é contextualizado, e algumas vezes nem todas as informações que constam do enunciado são necessárias para a resolução do problema. Portanto, os competidores devem exercitar a capacidade de extrair as informações pertinentes à resolução do problema, diferenciando-as daquelas que simplesmente descrevem o cenário. As restrições, que são informações sobre o limite das instâncias de teste, também são apresentadas no enunciado.

--- a/programacao_competitiva/material_consulta.md
+++ b/programacao_competitiva/material_consulta.md
@@ -4,7 +4,7 @@ layout: template
 filename: material_consulta
 button: Material para consulta
 type: programacao_competitiva
-order: 5
+order: 6
 ---
 # Materiais complementares
 

--- a/programacao_competitiva/material_consulta.md
+++ b/programacao_competitiva/material_consulta.md
@@ -4,6 +4,7 @@ layout: template
 filename: material_consulta
 button: Material para consulta
 type: programacao_competitiva
+order: 5
 ---
 # Materiais complementares
 

--- a/programacao_competitiva/sistema_automaticos.md
+++ b/programacao_competitiva/sistema_automaticos.md
@@ -4,6 +4,7 @@ layout: template
 filename: sistema_automaticos
 button: Sistemas automáticos de avaliação
 type: programacao_competitiva
+order: 3
 ---
 
 # Sistemas automáticos de avaliação


### PR DESCRIPTION
Organiza os tópicos da página de Programação Competitiva em ordem didática, conforme descrito pela issue https://github.com/E2PC/ProjectPage/issues/46.
Foi adiconado uma váriavel "order" nos arquivos pertencentes às páginas de programação competitiva, sendo esta usada como critério de ordenação.

Closes https://github.com/E2PC/ProjectPage/issues/46.