### PR TITLE
Mudar ordenção cards Equipe

### DIFF
--- a/_equipe/alexandro_rocha.md
+++ b/_equipe/alexandro_rocha.md
@@ -2,7 +2,7 @@
 name: Alexandro Luis da Rocha Jr
 type: Monitor
 begin_year: 2019
-end_year: 
+end_year: 2022
 linkedin: https://www.linkedin.com/in/alexandro-luis-184140190/
 github: https://github.com/AlexandroLuis
 link: alexandroluis.github.io/Portfolio

--- a/info/equipe.md
+++ b/info/equipe.md
@@ -6,7 +6,7 @@ button: Equipe
 type: info
 ---
 
-{% assign todos_equipe = site.equipe | sort_natural:"name" | sort:"end_year" %}
+{% assign todos_equipe = site.equipe | sort:"end_year", "last" | reverse %}
 ![](../assets/images/logo_e2pc.png) 
 
 ## Equipe do Projeto  
@@ -24,6 +24,8 @@ type: info
                     <p class="mb-0 small text-muted align-center">{{ pessoa.type }}</p>
                     {% if pessoa.end_year %}
                         <p class="small text-muted">{{ pessoa.begin_year }} - {{ pessoa.end_year }}</p>
+                    {% else %}
+                        <p class="small text-muted">{{ pessoa.begin_year }} - Atualmente</p>
                     {% endif %}
                     <ul class="social mb-0 list-inline mt-3">
                         {% if pessoa.github %}


### PR DESCRIPTION
Fiz uma alteração na ordenação dos membros da equipe. A modificação faz com que os ex-membros aparecem em ordem descrescente, ou seja, os que saíram no ano de 2022 aparecem antes que os que deixaram o projeto em 2011. Os membros atuais aparecem em primeiro.
Outra alteração foi adicionar o ano de início de um membro atual, seguido da palavra "atualmente" para esclarecer que está ativo. Segue uma imagem com os cards.

![image](https://user-images.githubusercontent.com/51726526/209598218-48301717-54e0-4b37-8928-e3eb54bfa852.png)

Closes #90 